### PR TITLE
Powder Drop for OpenTrickler

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -1,0 +1,60 @@
+[bluetooth]
+name = Trickler
+
+
+[scale]
+# See the SCALES variable in scales.py for options.
+model = and-fx120
+port = /dev/ttyUSB0
+baudrate = 19200
+timeout = 0.1
+
+
+[motors]
+trickler_pin = 18
+trickler_max_pwm = 100
+trickler_min_pwm = 32
+thrower_dir_pin = 6
+thrower_step_pin = 12
+thrower_enable_pin = 13
+thrower_step_count = 180
+#servo_pin = 
+
+
+[leds]
+# https://gpiozero.readthedocs.io/en/stable/recipes_advanced.html#controlling-the-pi-s-own-leds
+status_led_pin = 47
+active_high = False
+enable_status_leds = True
+ready_status_led_mode = pulse
+running_status_led_mode = on
+done_status_led_mode = fast_blink
+
+
+[PID]
+# Higher Kp values will:
+# - decrease rise time
+# - increase overshoot
+# - slightly increase settling time
+# - decrease steady-state error
+# - degrade stability
+# - initial value 10
+Kp = 3
+# Higher Ki values will:
+# - slightly decrease rise time
+# - increase overshoot
+# - increase settling time
+# - largely decrease steady-state error
+# - degrade stability
+# - initial value 2.3
+Ki = 2.3
+# Higher Kd values will:
+# - slightly decrease rise time
+# - decrease overshoot
+# - decrease settling time
+# - minorly affect steady-state error
+# - improve stability
+# - initial value 3.75
+Kd = 3.75
+# Enable for use with pidtuner.com
+pid_tuner_mode = False

--- a/main.py
+++ b/main.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""
+Copyright (c) Ammolytics and contributors. All rights reserved.
+Released under the MIT license. See LICENSE file in the project root for details.
+
+OpenTrickler
+https://github.com/ammolytics/projects/tree/develop/trickler
+"""
+
+import datetime
+import decimal
+import logging
+import time
+
+import constants
+import helpers
+import PID
+import motors
+import scales
+
+
+# Components:
+# 0. Server (Pi)
+# 1. Scale (serial)
+# 2. Trickler (gpio/PWM)
+# 3. Dump (gpio/servo?)
+# 4. API
+# 6. Bluetooth?
+# 7: Powder pan/cup?
+
+# TODO
+# - document specific python version
+# - handle case where scale is booted with pan on -- shows error instead of negative value
+# - detect scale that's turned off (blank values)
+# - validate inputs (target weight)
+
+def trickler_loop(memcache, pid, trickler_motor, scale, target_weight, target_unit, pidtune_logger):
+    pidtune_logger.info('timestamp, input (motor %), output (weight %)')
+    logging.info('Starting trickling process...')
+    
+    while 1:
+        # Stop running if auto mode is disabled.
+        if not memcache.get(constants.AUTO_MODE):
+            logging.debug('auto mode disabled.')
+            logging.info('auto mode disabled.')
+            break
+
+        # Read scale values (weight/unit/stable)
+        scale.update()
+
+        # Stop running if scale's unit no longer matches target unit.
+        if scale.unit != target_unit:
+            logging.debug('Target unit does not match scale unit.')
+            break
+
+        # Stop running if pan removed.
+        if scale.weight < 0:
+            logging.debug('Pan removed.')
+            logging.info('Pan removed.')            
+            break
+
+        remainder_weight = target_weight - scale.weight
+        logging.debug('remainder_weight: %r', remainder_weight)
+      
+        # If pan is empty, throw bulk charge exactly One time
+        #logging.info('remainder_weight: %r', remainder_weight)        
+        #if remainder_weight >= (target_weight * decimal.Decimal('.9')):
+        #    logging.info('Throwing bulk charge.')            
+        #    thrower_motor.throwCharge()
+        #    time.sleep(1)
+        
+        pidtune_logger.info(
+            '%s, %s, %s',
+            datetime.datetime.now().timestamp(),
+            trickler_motor.speed,
+            scale.weight / target_weight)
+
+        # Trickling complete.
+        if remainder_weight <= 0:
+            logging.debug('Trickling complete, motor turned off and PID reset.')
+            logging.info('Powder Charge complete, motor turned off and PID reset.')
+            break
+
+        # PID controller requires float value instead of decimal.Decimal
+        pid.update(float(scale.weight / target_weight) * 100)
+        trickler_motor.update(pid.output)
+        logging.debug('trickler_motor.speed: %r, pid.output: %r', trickler_motor.speed, pid.output)
+        logging.info(
+            'remainder: %s %s scale: %s %s motor: %s',
+            remainder_weight,
+            target_unit,
+            scale.weight,
+            scale.unit,
+            trickler_motor.speed)
+
+    # Clean up tasks.
+    trickler_motor.off()
+    #thrower_motor.off()
+    # Clear PID values.
+    pid.clear()
+    logging.info('Trickling process stopped.')
+
+def main(config, args, pidtune_logger):
+
+    memcache = helpers.get_mc_client()
+
+    pid = PID.PID(
+        float(config['PID']['Kp']),
+        float(config['PID']['Ki']),
+        float(config['PID']['Kd']))
+    logging.debug('pid: %r', pid)
+
+    trickler_motor = motors.TricklerMotor(
+        memcache=memcache,
+        motor_pin=int(config['motors']['trickler_pin']),
+        min_pwm=int(config['motors']['trickler_min_pwm']),
+        max_pwm=int(config['motors']['trickler_max_pwm']))
+    logging.debug('trickler_motor: %r', trickler_motor)
+    #servo_motor = gpiozero.AngularServo(int(config['motors']['servo_pin']))
+  
+    thrower_motor = motors.ThrowerMotor(
+        memcache=memcache,
+        dir_pin=int(config['motors']['thrower_dir_pin']),
+        step_pin=int(config['motors']['thrower_step_pin']),
+        enable_pin=int(config['motors']['thrower_enable_pin']),
+        step_count=int(config['motors']['thrower_step_count']))
+    logging.debug('thrower_motor: %r', thrower_motor)   
+ 
+    scale = scales.SCALES[config['scale']['model']](
+        memcache=memcache,
+        port=config['scale']['port'],
+        baudrate=int(config['scale']['baudrate']),
+        timeout=float(config['scale']['timeout']))
+    logging.debug('scale: %r', scale)
+
+    memcache.set(constants.AUTO_MODE, args.auto_mode or False)
+    memcache.set(constants.TARGET_WEIGHT, args.target_weight or decimal.Decimal('0.0'))
+    memcache.set(constants.TARGET_UNIT, scales.UNIT_MAP.get(args.target_unit, 'GN'))
+
+    while 1:
+        # Update settings.
+        auto_mode = memcache.get(constants.AUTO_MODE)
+        target_weight = memcache.get(constants.TARGET_WEIGHT)
+        target_unit = memcache.get(constants.TARGET_UNIT)
+        # Use percentages for PID control to avoid complexity w/ different units of weight.
+        pid.SetPoint = 100.0
+        scale.update()
+
+        # Set scale to match target unit.
+        if target_unit != scale.unit:
+            logging.info('scale.unit: %r, target_unit: %r', scale.unit, target_unit)
+            scale.change_unit()
+
+        logging.info(
+            'target: %s %s scale: %s %s auto_mode: %s',
+            target_weight,
+            target_unit,
+            scale.weight,
+            scale.unit,
+            auto_mode)
+
+        remainder_weight = target_weight - scale.weight
+        # Powder pan is empty, scale stable, ready to throw.
+        # Changed scale.weight >= 0 to scale.weight == 0, Scale must be 0 to proceed
+        if (scale.weight == 0 and
+                scale.weight < target_weight and
+                scale.unit == target_unit and
+                scale.is_stable and
+                auto_mode):                
+            # Throw bulk charge exactly One time if remainder_weight greater than 90% of target_weight
+            if remainder_weight >= (target_weight  * decimal.Decimal('.9')):
+                logging.info('Throwing bulk charge.')          
+                # Run thrower loop.
+                thrower_motor.throwCharge()
+                # Wait in case the scale needs a chance to settle
+                time.sleep(1)  
+                #while not scale.is_stable:
+                
+            # Wait a second to start trickling.
+            time.sleep(1)
+            # Run trickler loop.
+            trickler_loop(memcache, pid, trickler_motor, scale, target_weight, target_unit, pidtune_logger)
+           
+if __name__ == '__main__':
+    import argparse
+    import configparser
+
+    parser = argparse.ArgumentParser(description='Run OpenTrickler.')
+    parser.add_argument('config_file')
+    parser.add_argument('--verbose', action='store_true')
+    parser.add_argument('--auto_mode', action='store_true')
+    parser.add_argument('--pid_tune', action='store_true')
+    parser.add_argument('--target_weight', type=decimal.Decimal, default=0)
+    parser.add_argument('--target_unit', choices=scales.UNIT_MAP.keys(), default='GN')
+    args = parser.parse_args()
+
+    config = configparser.ConfigParser()
+    config.read_file(open(args.config_file))
+
+    log_level = logging.INFO
+    if args.verbose:
+        log_level = logging.DEBUG
+
+    helpers.setup_logging(log_level)
+
+    pidtune_logger = logging.getLogger('pid_tune')
+    pid_handler = logging.StreamHandler()
+    pid_handler.setFormatter(logging.Formatter('%(message)s'))
+
+    pidtune_logger.setLevel(logging.ERROR)
+    if args.pid_tune or config['PID'].getboolean('pid_tuner_mode'):
+        pidtune_logger.setLevel(logging.INFO)
+
+    main(config, args, pidtune_logger)

--- a/motors.py
+++ b/motors.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""
+Copyright (c) Ammolytics and contributors. All rights reserved.
+Released under the MIT license. See LICENSE file in the project root for details.
+
+OpenTrickler
+https://github.com/ammolytics/projects/tree/develop/trickler
+"""
+
+import atexit
+import logging
+import time
+
+import gpiozero # pylint: disable=import-error;
+
+import constants
+
+class ThrowerMotor:
+    #Controls a stepper motor with the Pi.
+
+    def __init__(self, memcache, dir_pin=6, step_pin=12, enable_pin=13, step_count=180):
+        """Constructor."""
+        self._memcache = memcache
+        self.dir = gpiozero.DigitalOutputDevice(dir_pin,True,False)   
+        self.step = gpiozero.DigitalOutputDevice(step_pin,True,False)
+        self.enable = gpiozero.DigitalOutputDevice(enable_pin,False,False)
+        self.spt = step_count        
+
+        logging.debug(
+            'Created stepper motor with Dir Pin %r Step Pin %r Enable Pin %r with step count %r: %r %r %r %r',
+            dir_pin,
+            step_pin,
+            enable_pin,
+            step_count,
+            self.dir,
+            self.step,
+            self.enable,
+            self.spt)
+        atexit.register(self._graceful_exit)
+
+    def _graceful_exit(self):
+        #Graceful exit function, turn off motor and close GPIO pin.
+        logging.debug('Closing thrower motor...')
+        self.dir.off()
+        self.step.off()
+        self.enable.off()
+        
+        self.dir.close()
+        self.step.close()
+        self.enable.close()
+        
+    def throwCharge(self): 
+        logging.info('In throwCharge(self) throwing charge.') 
+    # Enable Stepper Motor
+        self.enable.on()   
+    # Clockwise Direction  
+        self.dir.on()
+    # Rotate Powder Drum to fill
+        for x in range(self.spt):
+            self.step.on()
+            time.sleep(.0001)
+            self.step.off()
+            time.sleep(.002)
+      
+    # Disable Stepper Motor, quites the motor hum
+        self.enable.off()
+        time.sleep(2)
+        
+    # Enable Stepper Motor
+        self.enable.on()
+    # CounterClockwise Direction  
+        self.dir.off()
+    # Return Powder Drum to discharge
+        for x in range(self.spt):
+            self.step.on()
+            time.sleep(.0001)
+            self.step.off()
+            time.sleep(.002)
+            
+    # Disable Stepper Motor, quites the motor hum
+        self.enable.off()    
+        
+    def off(self):
+        """Turns stepper off."""
+        self.dir.off()
+        self.step.off()
+                
+        
+class TricklerMotor:
+    """Controls a small vibration DC motor with the PWM controller on the Pi."""
+    
+    def __init__(self, memcache, motor_pin=18, min_pwm=15, max_pwm=100):
+        """Constructor."""
+        self._memcache = memcache
+        self.pwm = gpiozero.PWMOutputDevice(motor_pin)
+        self.min_pwm = min_pwm
+        self.max_pwm = max_pwm
+        logging.debug(
+            'Created pwm motor on PIN %r with min %r and max %r: %r',
+            motor_pin,
+            self.min_pwm,
+            self.max_pwm,
+            self.pwm)
+        atexit.register(self._graceful_exit)
+
+    def _graceful_exit(self):
+        """Graceful exit function, turn off motor and close GPIO pin."""
+        logging.debug('Closing trickler motor...')
+        self.pwm.off()
+        self.pwm.close()
+
+    def update(self, target_pwm):
+        """Change PWM speed of motor (int), enforcing clamps."""
+        logging.debug('Updating target_pwm to %r', target_pwm)
+        target_pwm = max(min(int(target_pwm), self.max_pwm), self.min_pwm)
+        logging.debug('Adjusted clamped target_pwm to %r', target_pwm)
+        self.set_speed(target_pwm / 100)
+
+    def set_speed(self, speed):
+        """Sets the PWM speed (float) and circumvents any clamps."""
+        # TODO(eric): must be 0 - 1.
+        logging.debug('Setting speed from %r to %r', self.speed, speed)
+        self.pwm.value = speed
+        self._memcache.set(constants.TRICKLER_MOTOR_SPEED, self.speed)
+
+    def off(self):
+        """Turns motor off."""
+        self.set_speed(0)
+
+    @property
+    def speed(self):
+        """Returns motor speed (float)."""
+        return self.pwm.value
+
+if __name__ == '__main__':
+    import argparse
+    import time
+
+    import helpers
+
+    parser = argparse.ArgumentParser(description='Test motors.')
+    parser.add_argument('--trickler_motor_pin', type=int, default=18)
+    parser.add_argument('--max_pwm', type=float, default=100)
+    parser.add_argument('--min_pwm', type=float, default=15)
+    #parser.add_argument('--servo_motor_pin', type=int)    
+    parser.add_argument('--thrower_dir_pin', type=int, default=6)
+    parser.add_argument('--thrower_step_pin', type=int, default=12)
+    parser.add_argument('--thrower_enable_pin', type=int, default=13)
+    parser.add_argument('--thrower_step_count', type=int, default=180)
+    
+    args = parser.parse_args()
+
+    memcache_client = helpers.get_mc_client()
+
+    helpers.setup_logging()
+
+    motor = TricklerMotor(
+        memcache=memcache_client,
+        motor_pin=args.trickler_motor_pin,
+        min_pwm=args.min_pwm,
+        max_pwm=args.max_pwm)
+    print('Spinning up trickler motor in 3 seconds...')
+    time.sleep(3)
+    for x in range(1, 101):
+        motor.set_speed(x / 100)
+        time.sleep(.05)
+    for x in range(100, 0, -1):
+        motor.set_speed(x / 100)
+        time.sleep(.05)
+    motor.off()
+    print('Done.')


### PR DESCRIPTION
[config.ini.txt](https://github.com/Shooter0423/projects/files/6192640/config.ini.txt)
[main.py.txt](https://github.com/Shooter0423/projects/files/6192641/main.py.txt)
[motors.py.txt](https://github.com/Shooter0423/projects/files/6192642/motors.py.txt)

These files are modified from the originals to allow for the use of a stepper motor activated powder measurer with the OpenTrickler project. Remove the .txt file extension 

A DRV8825 Stepper driver, hardwire configured for FULL steps, is connected to the Pi as follows:
   GPIO6 -> Direction Pin
   GPIO12 -> Step Pin
   GPIO13 -> Enable Pin
I used a NEMA 17 stepper motor to activate a Lee Deluxe Perfect Powder Measure with a 2GT (GT2) 60 tooth Pulley on the measurer and a 20 tooth Pulley on the motor connected with a 200mm belt.